### PR TITLE
fixed minor issue, added a comma to seperate lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "angular-patternfly": "^4.13.3",
     "express": "^4.15.3",
-    "firebaseui": "^2.5.1"
+    "firebaseui": "^2.5.1",
     "socket.io": "^2.0.4"
   },
   "homepage": "https://github.com/jboss-outreach/lead-management-server#readme"


### PR DESCRIPTION
a comma was missing in package.json file, which was leading to parsing issue


`"dependencies": {
   ...,
    "firebaseui": "^2.5.1"  **_here_**
    "socket.io": "^2.0.4"
  },`
